### PR TITLE
♻️ checkpoint 코드 정리 및 통일 리팩토링

### DIFF
--- a/SchoolRush/Assets/Scripts/CheckpointIdentifier.cs
+++ b/SchoolRush/Assets/Scripts/CheckpointIdentifier.cs
@@ -1,22 +1,14 @@
 using UnityEngine;
 
-public class CheckpointIdentifier : MonoBehaviour
-{
-    [Tooltip("1~5는 체크포인트, 6은 도착 지점")]
+public class CheckpointIdentifier : MonoBehaviour {
+    [Tooltip("0은 시작 지점, 1~5는 체크포인트, 6은 도착 지점")]
     public int ID;
 
     [SerializeField]
     private UpgradeManager upgradeManager;
 
-    private void Start()
-    {
-        
-    }
-
-    private void OnTriggerEnter(Collider other)
-    {
-        if (other.CompareTag("Player"))
-        {
+    private void OnTriggerEnter(Collider other) {
+        if (other.CompareTag("Player") && ID >= 1 && ID <= 4) {
             upgradeManager.PickUpgrade(ID);
         }
     }

--- a/SchoolRush/Assets/Scripts/Kart/KartController.cs
+++ b/SchoolRush/Assets/Scripts/Kart/KartController.cs
@@ -360,4 +360,3 @@ public enum ShieldResult {
   Succeed,
   Failed
 }
-

--- a/SchoolRush/Assets/Scripts/Upgrades/UpgradeManager.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/UpgradeManager.cs
@@ -25,8 +25,6 @@ public class UpgradeManager : MonoBehaviour
     }
 
     public void PickUpgrade(int checkpoint) {
-        if (checkpoint == 5) return;
-
         upgradeUI.SetActive(true);
         Time.timeScale = 0;
         List<Upgrade> upgrades = new List<Upgrade>(); // should be length 3


### PR DESCRIPTION
## Description

Checkpoint 관련 로직을 리팩토링합니다.
- 여기저기 index 와 id가 혼동되고 있어 0을 시작 지점, 1~5를 체크포인트 1~5, 6을 도착 지점으로 통일했습니다.
- `CheckpointIdentifier.KartController` 등 불필요한 요소를 제거했습니다.
- `CheckpointManager` 코드를 정리합니다.

[여기](https://2025springswppimo.slack.com/archives/C08KVGJU4H4/p1750087862110059?thread_ts=1750087510.820649&cid=C08KVGJU4H4)서 언급한 개발용 치트키 개발을 편하게 하기 위한 전초작업이기도 합니다.

## Screenshot

리팩토링이므로 변경사항은 없습니다.
