### PR TITLE
🧑‍💻 개발용 cheat: ctrl+숫자 입력 시 해당 체크포인트로 이동

### DIFF
--- a/SchoolRush/Assets/Scripts/Kart/CheckpointManager.cs
+++ b/SchoolRush/Assets/Scripts/Kart/CheckpointManager.cs
@@ -1,6 +1,10 @@
 using UnityEngine;
 using System;
 
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
 public class CheckpointManager : MonoBehaviour
 {
     public KartController kartController;
@@ -15,6 +19,21 @@ public class CheckpointManager : MonoBehaviour
             checkpoints[i].SetActive(false);
 
         OnEnterCheckpoint(0);
+    }
+
+    void Update() {
+        // 개발용 치트키: checkpoint 로 순간이동
+        #if UNITY_EDITOR
+        if (Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl)) {
+            for (int i = 0; i <= 6; i++) {
+                if (Input.GetKeyDown(KeyCode.Alpha0 + i) || Input.GetKeyDown(KeyCode.Keypad0 + i)) {
+                    Debug.Log($"Cheat: Teleporting to checkpoint {i}");
+                    GoToCheckPoint(i);
+                    break;
+                }
+            }
+        }
+        #endif
     }
 
     void OnTriggerEnter(Collider other) {


### PR DESCRIPTION
## Description

관련 논의 스레드: [여기](https://2025springswppimo.slack.com/archives/C08KVGJU4H4/p1750087862110059?thread_ts=1750087510.820649&cid=C08KVGJU4H4) 및 과거 구두 논의

개발 시 일일이 체크포인트를 찾아가면서 테스트하려면 15분씩 걸리므로 다음 체크포인트로 순간이동하는 개발용 치트키를 추가합니다.

윈도우와 맥 모두 대응할 수 있게 하기 위해 `ctrl + 숫자` 로 합니다.

## Screenshot

https://github.com/user-attachments/assets/a6a0051e-db4b-4810-be85-7a9eed2d5238


