### PR TITLE
camera pos adjust

### DIFF
--- a/SchoolRush/Assets/Scripts/Kart/KartController.cs
+++ b/SchoolRush/Assets/Scripts/Kart/KartController.cs
@@ -154,7 +154,7 @@ public class KartController : MonoBehaviour
             float control = (driftDirection == 1) ? ExtensionMethods.Remap(input, -1, 1, 0, 2) : ExtensionMethods.Remap(input, -1, 1, 2, 0);
             float powerControl = (driftDirection == 1) ? ExtensionMethods.Remap(input, -1, 1, .2f, 1) : ExtensionMethods.Remap(input, -1, 1, 1, .2f);
             Steer(driftDirection, control);
-            driftPower += powerControl * Time.deltaTime * 90;
+            driftPower += powerControl * Time.deltaTime * 120;
             UpdateDriftEffects();
 
             // End Drift


### PR DESCRIPTION
## Description

카메라의 위치 조정(아래에 방법 첨부)


## Screenshot

- before

<img width="910" alt="image" src="https://github.com/user-attachments/assets/08f092fd-5b1d-4bee-87b9-95820175f4db" />

- after

<img width="931" alt="image" src="https://github.com/user-attachments/assets/f1789586-ac2b-4c66-bee3-655a795b51c7" />

## Review Points
Main Camera의 직접적인 조정이 불가능한데  CinemachineVirtualCamera를 이용하고 있기 때문입니다.

CM vcam1 > CinemachineVirtualCamera > body> following offset을 Y 3 Z-13 으로 조정

## Notion Task Link

<!-- 무슨 태스크를 진행한 건지, 노션 태스크 링크를 첨부해주세요. 없으면 스킵 -->
