### PR TITLE
고른 증강 안보이는 버그 픽스

### DIFF
--- a/SchoolRush/Assets/Scripts/Data/PlayerData.cs
+++ b/SchoolRush/Assets/Scripts/Data/PlayerData.cs
@@ -18,6 +18,10 @@ public class PlayerData {
         this.logs.Add(new Log((int)System.DateTimeOffset.UtcNow.ToUnixTimeSeconds(), position));
     }
 
+    public void InsertUpgrade(Upgrade upgrade) {
+        this.augmentIds.Add(upgrade.GetId());
+    }
+
     public void Save(int totalTime) {
         this.totalTime = totalTime;
         PlayerDataSaveLoad.SaveData(this);

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrade.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrade.cs
@@ -1,8 +1,10 @@
 public abstract class Upgrade {
+    private int id;
     private string title;
     private string description;
 
-    public Upgrade(string title, string description) {
+    public Upgrade(int id, string title, string description) {
+        this.id = id;
         this.title = title;
         this.description = description;
     }
@@ -13,6 +15,10 @@ public abstract class Upgrade {
 
     public string GetDescription() {
         return description;
+    }
+
+    public int GetId() {
+        return id;
     }
 
     public virtual void OnPick() {}

--- a/SchoolRush/Assets/Scripts/Upgrades/UpgradeManager.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/UpgradeManager.cs
@@ -97,6 +97,7 @@ public class UpgradeManager : MonoBehaviour
     {
         upgradeUI.SetActive(false);
         upgrade.OnPick();
+        kartController.GetPlayerData().InsertUpgrade(upgrade);
         Time.timeScale = 1;
         selectedUpgrades.Add(upgrade);
 

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade101.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade101.cs
@@ -2,7 +2,7 @@ public class Upgrade101 : Upgrade {
     private KartController kartController;
     private readonly static float rate = 1.3f;
 
-    public Upgrade101(KartController kartController): base("최고 속도 증가", GetDescription(kartController)) {
+    public Upgrade101(KartController kartController): base(101, "최고 속도 증가", GetDescription(kartController)) {
         this.kartController = kartController;
     }
 

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade102.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade102.cs
@@ -2,7 +2,7 @@ public class Upgrade102 : Upgrade {
     private KartController kartController;
     private readonly static float rate = 1.3f;
 
-    public Upgrade102(KartController kartController): base("가속도 증가", GetDescription(kartController)) {
+    public Upgrade102(KartController kartController): base(102, "가속도 증가", GetDescription(kartController)) {
         this.kartController = kartController;
     }
 

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade103.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade103.cs
@@ -1,5 +1,5 @@
 public class Upgrade103 : Upgrade {
-    public Upgrade103(): base("통행 금지령", GetDescription()) {
+    public Upgrade103(): base(103, "통행 금지령", GetDescription()) {
 
     }
 

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade104.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade104.cs
@@ -1,5 +1,5 @@
 public class Upgrade104 : Upgrade {
-    public Upgrade104(): base("친환경 정책", GetDescription()) {
+    public Upgrade104(): base(104, "친환경 정책", GetDescription()) {
 
     }
 

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade105.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade105.cs
@@ -2,7 +2,7 @@ public class Upgrade105 : Upgrade {
     private KartController kartController;
     private readonly static int count = 10;
 
-    public Upgrade105(KartController kartController): base("집행유예", GetDescription()) {
+    public Upgrade105(KartController kartController): base(105, "집행유예", GetDescription()) {
         this.kartController = kartController;
     }
 

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade201.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade201.cs
@@ -2,7 +2,7 @@ public class Upgrade201 : Upgrade {
     private KartController kartController;
     private readonly static float rate = 1.5f;
 
-    public Upgrade201(KartController kartController): base("최고 속도 증가", GetDescription(kartController)) {
+    public Upgrade201(KartController kartController): base(201, "최고 속도 증가", GetDescription(kartController)) {
         this.kartController = kartController;
     }
 

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade202.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade202.cs
@@ -2,7 +2,7 @@ public class Upgrade202 : Upgrade {
     private KartController kartController;
     private readonly static float rate = 1.5f;
 
-    public Upgrade202(KartController kartController): base("가속도 증가", GetDescription(kartController)) {
+    public Upgrade202(KartController kartController): base(202, "가속도 증가", GetDescription(kartController)) {
         this.kartController = kartController;
     }
 

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade203.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade203.cs
@@ -2,7 +2,7 @@ public class Upgrade203 : Upgrade {
     private KartController kartController;
     private readonly static float rate = 2f;
 
-    public Upgrade203(KartController kartController): base("오버클럭", GetDescription(kartController)) {
+    public Upgrade203(KartController kartController): base(203, "오버클럭", GetDescription(kartController)) {
         this.kartController = kartController;
     }
 

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade204.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade204.cs
@@ -2,7 +2,7 @@ public class Upgrade204 : Upgrade {
     private KartController kartController;
     private readonly static float rate = 2f;
 
-    public Upgrade204(KartController kartController): base("지각이다", GetDescription()) {
+    public Upgrade204(KartController kartController): base(204, "지각이다", GetDescription()) {
         this.kartController = kartController;
     }
 

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade301.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade301.cs
@@ -2,7 +2,7 @@ public class Upgrade301 : Upgrade {
     private KartController kartController;
     private readonly static float rate = 1.5f;
 
-    public Upgrade301(KartController kartController): base("최고 속도 증가", GetDescription(kartController)) {
+    public Upgrade301(KartController kartController): base(301, "최고 속도 증가", GetDescription(kartController)) {
         this.kartController = kartController;
     }
 

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade302.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade302.cs
@@ -4,7 +4,7 @@ public class Upgrade302 : Upgrade {
     private KartController kartController;
     private static readonly float[] rates = { 1.2f, 1.6f, 2.0f };
 
-    public Upgrade302(KartController kartController): base("창업", GetDescription()) {
+    public Upgrade302(KartController kartController): base(302, "창업", GetDescription()) {
         this.kartController = kartController;
     }
 

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade303.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade303.cs
@@ -2,7 +2,7 @@ public class Upgrade303 : Upgrade {
     private KartController kartController;
     private readonly static float rate = 1.2f;
 
-    public Upgrade303(KartController kartController): base("레버리지", GetDescription(kartController)) {
+    public Upgrade303(KartController kartController): base(303, "레버리지", GetDescription(kartController)) {
         this.kartController = kartController;
     }
 

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade401.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade401.cs
@@ -2,7 +2,7 @@ public class Upgrade401 : Upgrade {
     private KartController kartController;
     private readonly static float rate = 1.5f;
 
-    public Upgrade401(KartController kartController): base("최고 속도 증가", GetDescription(kartController)) {
+    public Upgrade401(KartController kartController): base(401, "최고 속도 증가", GetDescription(kartController)) {
         this.kartController = kartController;
     }
 

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade402.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade402.cs
@@ -1,7 +1,7 @@
 public class Upgrade402 : Upgrade {
     private BGMController bgmController;
 
-    public Upgrade402(BGMController bgmController): base("축제", GetDescription()) {
+    public Upgrade402(BGMController bgmController): base(402, "축제", GetDescription()) {
         this.bgmController = bgmController;
     }
 

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade403.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade403.cs
@@ -1,5 +1,5 @@
 public class Upgrade403 : Upgrade {
-    public Upgrade403(): base("신나", GetDescription()) {
+    public Upgrade403(): base(403, "신나", GetDescription()) {
 
     }
 

--- a/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade404.cs
+++ b/SchoolRush/Assets/Scripts/Upgrades/Upgrades/Upgrade404.cs
@@ -1,5 +1,5 @@
 public class Upgrade404 : Upgrade {
-    public Upgrade404(): base("관공이의 가호", GetDescription()) {
+    public Upgrade404(): base(404, "관공이의 가호", GetDescription()) {
 
     }
 


### PR DESCRIPTION
## Description

#46 에서 구현하다 말았던, 고른 증강이 랭킹 대시보드에 보이도록 하는 작업을 합니다.