### PR TITLE
💄 속도 단위 안 보여주기 & 미니맵 배율 조정

### DIFF
--- a/SchoolRush/Assets/Scripts/GameController/HUDController.cs
+++ b/SchoolRush/Assets/Scripts/GameController/HUDController.cs
@@ -30,7 +30,7 @@ public class HUDController : MonoBehaviour
         // Update speed
         float speed = playerRigidbody.velocity.magnitude;
         if (speedText != null)
-            speedText.text = string.Format("{0:0.0} m/s", speed);
+            speedText.text = string.Format("{0:0.0}", speed);
 
         // Update shields
         if (shieldsText != null)

--- a/SchoolRush/Assets/Scripts/Map/MMIndicator.cs
+++ b/SchoolRush/Assets/Scripts/Map/MMIndicator.cs
@@ -24,7 +24,7 @@ public class MMIndicator : MonoBehaviour
         Vector3 pos = transform.position;
         transform.position = new(pos.x, player.transform.position.y + 30, pos.z);
 
-        distUI.text = $"{vector.magnitude:F0}m";
+        distUI.text = $"{(vector.magnitude / 3):F0}m";
     }
 
     public void SetCheckpoint(GameObject cp)


### PR DESCRIPTION
## Description

속도 단위가 실제로 m/s 가 아니어서, 안 보여주는 게 나을 것 같습니다. (원래 뭔지 모르겠음)
거리 단위는 대충 아는데 미니맵에서 보이는 것보다 1/3 하면 될 것 같습니다.

## Screenshot

<img width="823" alt="image" src="https://github.com/user-attachments/assets/1e069d55-20cd-4886-9587-0588a61368fa" />

