### PR TITLE
y축 diff는 고려하지 않는다 + main 브랜치에서 동작 안하는것들 픽스

### DIFF
--- a/SchoolRush/Assets/Scripts/Map/MMIndicator.cs
+++ b/SchoolRush/Assets/Scripts/Map/MMIndicator.cs
@@ -15,6 +15,7 @@ public class MMIndicator : MonoBehaviour
     private void Update()
     {
         Vector3 vector = checkpoint.transform.position - player.transform.position;
+        vector.y = 0;
         Vector3 dir = Vector3.Normalize(vector);
         transform.position = player.transform.position + (length + amp * Mathf.Sin(Time.time * freq)) * dir;
 

--- a/SchoolRush/ProjectSettings/TagManager.asset
+++ b/SchoolRush/ProjectSettings/TagManager.asset
@@ -12,6 +12,7 @@ TagManager:
   - Checkpoint
   - Terrain
   - Road
+  - Building
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## Description

checkpoint 까지의 거리를 계산할 때 y축 diff는 고려하지 않습니다.
main 브랜치에서 building 태그가 없고 스크립트가 일부 할당되지 않아 점프도 안되고 이것저것 터지고 있었는데 픽스합니다.

## Screenshot

![image](https://github.com/user-attachments/assets/f91c248a-f54f-47b4-b888-b87bf91402f8)

(기존에는 70m 정도로 떴습니다)
