### PR TITLE
playerData 10초마다 저장하도록 변경

### DIFF
--- a/SchoolRush/Assets/Scripts/Kart/KartController.cs
+++ b/SchoolRush/Assets/Scripts/Kart/KartController.cs
@@ -90,7 +90,7 @@ public class KartController : MonoBehaviour
         CacheParticles();
 
         playerData = new PlayerData(SaveNickname.LoadNickname());
-        StartCoroutine(Per10SecondsUpdate());
+        StartCoroutine(PerSecondUpdate());
         StartCoroutine(CheckTagBelow());
 
         taxi.gameObject.SetActive(false);
@@ -115,12 +115,12 @@ public class KartController : MonoBehaviour
         }
     }
 
-    private IEnumerator Per10SecondsUpdate()
+    private IEnumerator PerSecondUpdate()
     {
         while (true)
         {
             playerData.Insert(transform.position);
-            yield return new WaitForSeconds(10f);
+            yield return new WaitForSeconds(1f);
         }
     }
 

--- a/web/src/app/_components/Item/index.tsx
+++ b/web/src/app/_components/Item/index.tsx
@@ -115,7 +115,7 @@ const MovePath = ({
 }: {
   logs: { time: number; position: { x: number; y: number } }[];
 }) => {
-  const [sliceIndex, increment] = useReducer((c) => c + 1, 0);
+  const [sliceIndex, increment] = useReducer((c) => c + 3, 0);
 
   useInterval(() => {
     if (sliceIndex < log.length) increment();


### PR DESCRIPTION
## Description

playerData 가 10초에 한번씩 저장되는데, 이러다 보니 후반으로 갈수록 속도가 워낙 빨라 동선이 각지고 부자연스럽게 보이는 문제가 있어 수정합니다.

데이터 양이 10배 늘어서 애니메이션 속도도 10배 느려져서, 보기 불편하지 않을 만큼 빠르게 조정했습니다 (3배)

## Screenshot

| before | after |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/d1d5d747-eae2-406c-9447-6c57e6ac08ed) |  ![image](https://github.com/user-attachments/assets/0261cdc2-3b83-4c5c-bad7-09d76c45d1ee) | 

