### PR TITLE
거리 레이블 뒤집어지는 이슈 픽스

### DIFF
--- a/SchoolRush/Assets/Scripts/Map/MMIndicator.cs
+++ b/SchoolRush/Assets/Scripts/Map/MMIndicator.cs
@@ -25,6 +25,10 @@ public class MMIndicator : MonoBehaviour
         Vector3 pos = transform.position;
         transform.position = new(pos.x, player.transform.position.y + 30, pos.z);
 
+        // Prevent from flipping over
+        if (transform.rotation.eulerAngles.x > 180)
+            transform.Rotate(new Vector3(-180, 0, 0));
+
         distUI.text = $"{(vector.magnitude / 3):F0}m";
     }
 


### PR DESCRIPTION
## Description

Fixed #180 

Problem:  When a GameObject looks at another GameObject, there are two valid normal vectors, which is the reason of sometimes flipping over.

Solution: Since 0 ~ 180 degrees is the range we want, Substract the angle in x direction with 180 when it's larger than 180 (Assume that 0 < x < 360).

