### PR TITLE
체크포인트 위치 상공으로 잡히는 버그 픽스

### DIFF
--- a/SchoolRush/Assets/Scripts/Kart/CheckpointManager.cs
+++ b/SchoolRush/Assets/Scripts/Kart/CheckpointManager.cs
@@ -52,6 +52,6 @@ public class CheckpointManager : MonoBehaviour
     }
 
     public void GoToCheckPoint(int id) {
-        transform.position = checkpoints[id].transform.position;
+        transform.position = checkpoints[id].transform.Find("PortPos").position;
     }
 }


### PR DESCRIPTION
## Description

Fixed #181 

Problem: GameObjects of checkpoints are in the air, which makes the initial state of Player be in air when they go back to the last checkpoint.

Solution: Add child GameObjects named "PortPos" to each checkpoint representing the expected position of checkpoints, and use "Transparent.Find()" method to get them.

## Screenshot

![Screenshot 2025-06-22 161003](https://github.com/user-attachments/assets/ed024e1a-327b-43c5-b59c-ac37b0197afb)
