### PR TITLE
🧑‍💻 빌드했을 때만 결과를 쌓는다

### DIFF
--- a/SchoolRush/Assets/Scripts/GameController/EndGameController.cs
+++ b/SchoolRush/Assets/Scripts/GameController/EndGameController.cs
@@ -13,9 +13,7 @@ public class EndGameController : MonoBehaviour
 
     void Start()
     {
-        if (endGameUI != null)
-            endGameUI.SetActive(false);
-
+        endGameUI.SetActive(false);
         hud = FindObjectOfType<HUDController>();
     }
 
@@ -32,15 +30,17 @@ public class EndGameController : MonoBehaviour
         hasEnded = true;
         Time.timeScale = 0f;
 
-        if (endGameUI != null)
-            endGameUI.SetActive(true);
-            finalPanel.SetActive(true);
+        endGameUI.SetActive(true);
+        finalPanel.SetActive(true);
 
         if (finalTimeText != null && hud != null)
             finalTimeText.text = hud.timeText.text;
 
         KartController kartController = FindObjectOfType<KartController>();
         PlayerData playerData = kartController.GetPlayerData();
+
+        #if !UNITY_EDITOR
         playerData.Save((int)(hud.GetElapsedTime() * 1000));
+        #endif
     }
 }


### PR DESCRIPTION
## Description

<img width="1425" alt="image" src="https://github.com/user-attachments/assets/fbf9317f-ad83-4047-a089-b526e06db6b2" />

위 사지진과 같이 테스트용으로 shortcut 사용해서 도착하여 생성된 playerData들이 계속 DB에 쌓이는 이슈가 있어서, 빌드했을 때만 결과를 쌓도록 변경합니다.

과정에서 불필요한 null check 로직들이 있어 제거합니다.

