### PR TITLE
🩹 닉네임 저장 안 되는 이슈 픽스

### DIFF
--- a/SchoolRush/Assets/Scripts/UI/SaveNickname.cs
+++ b/SchoolRush/Assets/Scripts/UI/SaveNickname.cs
@@ -13,15 +13,18 @@ public class SaveNickname : MonoBehaviour {
             string savedName = PlayerPrefs.GetString(NICKNAME_KEY);
             nicknameInputField.text = savedName;
         }
-    }
 
-    public void SaveNicknameClick() {
-        string nickname = nicknameInputField.text;
-        PlayerPrefs.SetString(NICKNAME_KEY, nickname);
-        PlayerPrefs.Save();
+        nicknameInputField.onValueChanged.AddListener(OnNicknameChanged);
     }
 
     public static string LoadNickname() {
         return PlayerPrefs.GetString(NICKNAME_KEY);
+    }
+
+    private void OnNicknameChanged(string value) {
+        string trimmed = value.Trim();
+        nicknameInputField.text = trimmed;
+        PlayerPrefs.SetString(NICKNAME_KEY, trimmed);
+        PlayerPrefs.Save();
     }
 }


### PR DESCRIPTION
## Description

PlayerPrefs 에 닉네임이 저장되지 않는 이슈가 있어서 픽스합니다. 원래 닉네임 저장 버튼이 따로 있었던 것 같은데 없어지면서 닉네임이 저장되지 않게 된 것 같아요

인풋 값 변경될때마다 저장하게 해서 픽스합니다.