### PR TITLE
RandomPicker 가 개수 1개만 뽑는 케이스도 대응할 수 있는지 테스트 추가

### DIFF
--- a/UnitTests/RandomPicker.test.cs
+++ b/UnitTests/RandomPicker.test.cs
@@ -60,5 +60,17 @@ namespace SchoolRush.Assets.Scripts.Utils.Tests
                 Assert.That(count, Is.GreaterThan(5700).And.LessThan(6300));
             }
         }
+
+        [Test]
+        public void Pick_ShouldWorkAnysize()
+        {
+            // Arrange
+            var items = new List<int> { 10 };
+            var picker = new RandomPicker<int>(items);
+
+            var result = picker.pick(1);
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result[0], Is.EqualTo(10));
+        }
     }
 }


### PR DESCRIPTION
#200 결과, 만약 이슈의 1안으로 가게 된다면 증강 개수가 1개인 케이스도 생길 수 있을 것 같습니다.

이 케이스도 처리됨을 비교적 보장하고 문서화하기 위해 해당 항목에 대한 테스트를 추가합니다.