### PR TITLE
🩹 도로에서 점프 가능한 이슈 픽스

### DIFF
--- a/SchoolRush/Assets/Scripts/Kart/KartController.cs
+++ b/SchoolRush/Assets/Scripts/Kart/KartController.cs
@@ -203,7 +203,7 @@ public class KartController : MonoBehaviour
             if (Input.GetKeyUp(KeyCode.LeftShift)) Boost();
         }
 
-        if (Input.GetKeyDown(KeyCode.Space) && isOnGround)
+        if (Input.GetKeyDown(KeyCode.Space) && this.GetCanJump())
         {
             am.PlayOneShot(am.jumpAudio);
 
@@ -467,7 +467,7 @@ public class KartController : MonoBehaviour
     }
 
     public bool GetCanJump() {
-        return isOnGround;
+        return roadRemainTime <= 0 && isOnGround;
     }
 
     public bool GetIsDrifting() {


### PR DESCRIPTION
## Description

fixed #192

기존에 isOnGround 가 terrain 에 닿으면 true가 되고, isOnGround 면 점프가 가능했다 보니
terrain 을 찍고 다시 도로로 돌아오면 도로에서도 점프가 가능했습니다.

점프 가능 체크 로직에 `roadRemainTime <= 0` 을 &&으로 추가했고, 점프 가능 여부를 체크하는 곳이 `Update()` 내부랑 `GetCanJump()` 내부가 있는데 두 곳에서 지식의 중복이 발생하여 Update 내부에서도 `GetCanJump` 를 사용하는 식으로 변경했습니다.

## Screenshot

### before

<img width="961" alt="image" src="https://github.com/user-attachments/assets/56cc8f84-2a6e-4e2a-8ec7-86a3146f04cd" />

### after

<img width="961" alt="image" src="https://github.com/user-attachments/assets/f43c8270-c076-4178-be77-8944bc807ceb" />
